### PR TITLE
[WIP] Fix Sticky

### DIFF
--- a/lib/components/application.js
+++ b/lib/components/application.js
@@ -18,7 +18,7 @@ class Application extends Component {
   }
 
   componentDidMount() {
-    store.on('change', files => {
+    store.on('change', (files) => {
       this.setState( { files });
     });
   }

--- a/lib/components/application.js
+++ b/lib/components/application.js
@@ -14,7 +14,7 @@ loadSavedFiles();
 class Application extends Component {
   constructor() {
     super();
-    this.state = { files: store.all() };
+    this.state = { files: store.all(), stickies: [] };
   }
 
   componentDidMount() {
@@ -28,7 +28,7 @@ class Application extends Component {
 
     return (
       <div>
-        <Controls {...activeFile}/>
+        <Controls {...activeFile} />
         <div className="files">
           <FileList files={this.state.files} />
           <ActiveFile file={activeFile} />

--- a/lib/components/controls.js
+++ b/lib/components/controls.js
@@ -20,8 +20,7 @@ module.exports = (activeFile) => {
   );
 };
 
-const createSticky = (activeFile) => {
-  store.addSticky(activeFile);
+const createSticky = () => {
   newSticky();
 };
 

--- a/lib/components/sticky-note.js
+++ b/lib/components/sticky-note.js
@@ -7,8 +7,6 @@ import { remote } from 'electron';
 const { toggleStickyAlwaysOnTop, stickyOnTop } = remote.require(`${__dirname}/../main`);
 import { ipcRenderer } from 'electron';
 
-// console.log(stickyOnTop)
-
 const currentWindow = remote.getCurrentWindow();
 
 class StickyNote extends Component {

--- a/lib/components/sticky-note.js
+++ b/lib/components/sticky-note.js
@@ -3,11 +3,18 @@ const lastActiveFile = require('../last-active-file');
 import store from '../store';
 import EditableNote from './editable-note';
 import updateContent from '../update-content';
+import { remote } from 'electron';
+const { toggleStickyAlwaysOnTop, stickyOnTop } = remote.require(`${__dirname}/../main`);
+import { ipcRenderer } from 'electron';
+
+// console.log(stickyOnTop)
+
+const currentWindow = remote.getCurrentWindow();
 
 class StickyNote extends Component {
   constructor() {
     super();
-    this.state = { note: lastActiveFile() };
+    this.state = { note: lastActiveFile(), onTop: true};
   }
 
   componentDidMount() {
@@ -15,14 +22,25 @@ class StickyNote extends Component {
       let updatedFile = files.find(file => file.id === this.state.note.id);
       this.setState( { note: updatedFile } );
     });
+    ipcRenderer.on('toggle-on-top', (event) => {
+      this.setState( { onTop: !this.state.onTop });
+    });
   }
 
   render() {
     let file = this.state.note;
     return (
-      <EditableNote {...file} className="sticky-note"/>
+      <div className='sticky-note'>
+        {toggleOnTopButton()}
+        <EditableNote {...file} className='sticky-note-body'/>
+      </div>
     );
   }
 }
+
+const toggleOnTopButton = () => {
+    let buttonName = stickyOnTop(currentWindow) ? "Unpin" : "Pin";
+    return   <button className="toggle-on-top" onClick={() => toggleStickyAlwaysOnTop(currentWindow)}>{buttonName}</button>;
+};
 
 export default StickyNote;

--- a/lib/components/sticky-note.js
+++ b/lib/components/sticky-note.js
@@ -4,8 +4,25 @@ import store from '../store';
 import EditableNote from './editable-note';
 import updateContent from '../update-content';
 
-module.exports = ({file}) => {
-  return (
-    <EditableNote {...file} className="sticky-note"/>
-  );
-};
+class StickyNote extends Component {
+  constructor() {
+    super();
+    this.state = { note: lastActiveFile() };
+  }
+
+  componentDidMount() {
+    store.on('change', files => {
+      let updatedFile = files.find(file => file.id === this.state.note.id);
+      this.setState( { note: updatedFile } );
+    });
+  }
+
+  render() {
+    let file = this.state.note;
+    return (
+      <EditableNote {...file} className="sticky-note"/>
+    );
+  }
+}
+
+export default StickyNote;

--- a/lib/components/sticky-note.js
+++ b/lib/components/sticky-note.js
@@ -18,7 +18,9 @@ class StickyNote extends Component {
   componentDidMount() {
     store.on('change', files => {
       let updatedFile = files.find(file => file.id === this.state.note.id);
-      this.setState( { note: updatedFile } );
+      if (this.state.note.content !== updatedFile.content) {
+        this.setState( { note: updatedFile } );
+      }
     });
     ipcRenderer.on('toggle-on-top', (event) => {
       this.setState( { onTop: !this.state.onTop });

--- a/lib/last-active-file.js
+++ b/lib/last-active-file.js
@@ -3,7 +3,7 @@ import store from './store';
 const lastActiveFile = (files) => {
   files = files || [];
   let file = files.find(file => file.active);
-  return file || store.findActiveFile() || store.newFile();
+  return file || store.findActiveFile() || store.all()[0] || store.newFile();
 };
 
 module.exports = lastActiveFile;

--- a/lib/last-active-file.js
+++ b/lib/last-active-file.js
@@ -1,8 +1,9 @@
 import store from './store';
 
 const lastActiveFile = (files) => {
+  files = files || [];
   let file = files.find(file => file.active);
-  return file || files[files.length - 1] || store.newFile();
+  return file || store.findActiveFile() || store.newFile();
 };
 
 module.exports = lastActiveFile;

--- a/lib/main.js
+++ b/lib/main.js
@@ -39,9 +39,20 @@ const updateWindows = (files) => {
   });
 };
 
+const toggleStickyAlwaysOnTop = (currentWindow) => {
+  currentWindow.setAlwaysOnTop(!currentWindow.isAlwaysOnTop());
+  currentWindow.webContents.send('toggle-on-top');
+};
+
+const stickyOnTop = (currentWindow) => {
+  return currentWindow.isAlwaysOnTop();
+};
+
 
 exports.openFile = require('./open-file');
 exports.saveFile = require('./save-file');
 exports.saveAllFiles = require('./save-all-files');
 exports.newSticky = newSticky;
 exports.updateWindows = updateWindows;
+exports.stickyOnTop = stickyOnTop;
+exports.toggleStickyAlwaysOnTop = toggleStickyAlwaysOnTop;

--- a/lib/main.js
+++ b/lib/main.js
@@ -12,6 +12,7 @@ let stickyCounter = 0;
 
 app.on('ready', () => {
   mainWindow = new BrowserWindow();
+  mainWindow.setSize(1000,700);
   mainWindow.loadURL(`file://${__dirname}/index.html`);
   allWindows = [{id: 'main', window: mainWindow}];
 });
@@ -40,7 +41,7 @@ const updateWindows = (files, currentWindow) => {
     return () => activeWindow.window.webContents.send('window-updated', files);
     // return activeWindow.call(this, 'window-updated', files);
   });
-  // console.log(windowsSend);
+
   async.parallel(windowsSend);
 };
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -7,11 +7,13 @@ const Selfup = require('selfup-rejs');
 const rejs = new Selfup();
 
 let mainWindow = null;
-let stickyWindow = null;
+let allWindows = null;
+let stickyCounter = 0;
 
 app.on('ready', () => {
   mainWindow = new BrowserWindow();
   mainWindow.loadURL(`file://${__dirname}/index.html`);
+  allWindows = [mainWindow];
 });
 
 app.on('window-all-closed', function(event) {
@@ -19,9 +21,11 @@ app.on('window-all-closed', function(event) {
 });
 
 const newSticky = () => {
-  stickyWindow = new BrowserWindow({
+  let stickyWindow = new BrowserWindow({
     'title-bar-style': 'hidden-inset'
   });
+  let id = ++stickyCounter;
+  allWindows = allWindows.concat(stickyWindow);
   stickyWindow.setSize(350,300);
   stickyWindow.setResizable(false);
   stickyWindow.setPosition(1050,50);
@@ -29,8 +33,15 @@ const newSticky = () => {
   stickyWindow.loadURL(`file://${__dirname}/sticky.html`);
 };
 
+const updateWindows = (files) => {
+  allWindows.forEach((activeWindow) => {
+    activeWindow.webContents.send('window-updated', files);
+  });
+};
+
 
 exports.openFile = require('./open-file');
 exports.saveFile = require('./save-file');
 exports.saveAllFiles = require('./save-all-files');
 exports.newSticky = newSticky;
+exports.updateWindows = updateWindows;

--- a/lib/main.js
+++ b/lib/main.js
@@ -3,8 +3,8 @@ const fs = require('fs');
 const app = electron.app;
 const dialog = electron.dialog;
 const BrowserWindow = electron.BrowserWindow;
-const Selfup = require('selfup-rejs');
-const rejs = new Selfup();
+const async = require('async');
+
 
 let mainWindow = null;
 let allWindows = null;
@@ -26,6 +26,7 @@ const newSticky = () => {
   });
   let id = ++stickyCounter;
   allWindows = allWindows.concat({ id, window: stickyWindow});
+
   stickyWindow.setSize(350,300);
   stickyWindow.setResizable(false);
   stickyWindow.setPosition(1050,50);
@@ -35,9 +36,10 @@ const newSticky = () => {
 };
 
 const updateWindows = (files, currentWindow) => {
-  allWindows.forEach((windowObject) => {
-    windowObject.window.webContents.send('window-updated', files, currentWindow);
+  windowsSend = allWindows.map(function(activeWindow) {
+    return activeWindow.call(this, 'window-updated', files);
   });
+  async.parallel(windowSend);
 };
 
 const removeFromAllWindows = (currentWindow) => {

--- a/lib/main.js
+++ b/lib/main.js
@@ -36,10 +36,12 @@ const newSticky = () => {
 };
 
 const updateWindows = (files, currentWindow) => {
-  windowsSend = allWindows.map(function(activeWindow) {
-    return activeWindow.call(this, 'window-updated', files);
+  let windowsSend = allWindows.map(function(activeWindow) {
+    return () => activeWindow.window.webContents.send('window-updated', files);
+    // return activeWindow.call(this, 'window-updated', files);
   });
-  async.parallel(windowSend);
+  // console.log(windowsSend);
+  async.parallel(windowsSend);
 };
 
 const removeFromAllWindows = (currentWindow) => {

--- a/lib/main.js
+++ b/lib/main.js
@@ -34,9 +34,9 @@ const newSticky = () => {
   stickyWindow.loadURL(`file://${__dirname}/sticky.html`);
 };
 
-const updateWindows = (files) => {
+const updateWindows = (files, currentWindow) => {
   allWindows.forEach((windowObject) => {
-    windowObject.window.webContents.send('window-updated', files);
+    windowObject.window.webContents.send('window-updated', files, currentWindow);
   });
 };
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -13,7 +13,7 @@ let stickyCounter = 0;
 app.on('ready', () => {
   mainWindow = new BrowserWindow();
   mainWindow.loadURL(`file://${__dirname}/index.html`);
-  allWindows = [mainWindow];
+  allWindows = [{id: 'main', window: mainWindow}];
 });
 
 app.on('window-all-closed', function(event) {
@@ -25,18 +25,23 @@ const newSticky = () => {
     'title-bar-style': 'hidden-inset'
   });
   let id = ++stickyCounter;
-  allWindows = allWindows.concat(stickyWindow);
+  allWindows = allWindows.concat({ id, window: stickyWindow});
   stickyWindow.setSize(350,300);
   stickyWindow.setResizable(false);
   stickyWindow.setPosition(1050,50);
   stickyWindow.setAlwaysOnTop(true);
+  stickyWindow.on('closed', () => removeFromAllWindows({id, window: stickyWindow}));
   stickyWindow.loadURL(`file://${__dirname}/sticky.html`);
 };
 
 const updateWindows = (files) => {
-  allWindows.forEach((activeWindow) => {
-    activeWindow.webContents.send('window-updated', files);
+  allWindows.forEach((windowObject) => {
+    windowObject.window.webContents.send('window-updated', files);
   });
+};
+
+const removeFromAllWindows = (currentWindow) => {
+  allWindows = allWindows.filter(browser => browser.id !== currentWindow.id);
 };
 
 const toggleStickyAlwaysOnTop = (currentWindow) => {
@@ -56,3 +61,4 @@ exports.newSticky = newSticky;
 exports.updateWindows = updateWindows;
 exports.stickyOnTop = stickyOnTop;
 exports.toggleStickyAlwaysOnTop = toggleStickyAlwaysOnTop;
+exports.removeFromAllWindows = removeFromAllWindows;

--- a/lib/save-file.js
+++ b/lib/save-file.js
@@ -2,9 +2,14 @@ const electron = require('electron');
 const fs = require('fs');
 const dialog = electron.dialog;
 import { remote } from 'electron';
+const app = electron.app;
 
 module.exports = (fileName, content, id, currentWindow) => {
-  if (fileName === 'New Note') fileName = `~/Documents/NewNote`;
+
+  if (fileName === 'New Note') {
+    let path = app.getPath('documents');
+    fileName = `${path}/NewNote`;
+  }
   dialog.showSaveDialog(
       {defaultPath: fileName},
     function (newFileName){

--- a/lib/sticky-renderer.js
+++ b/lib/sticky-renderer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from 'react-dom';
-import EditableNote from './components/editable-note';
+import StickyNote from './components/sticky-note';
 import store from './store';
 
-render(<EditableNote {...store.findActiveFile()} className='sticky-note' />, document.querySelector('.sticky'));
+render(<StickyNote />, document.querySelector('.sticky'));

--- a/lib/sticky-renderer.js
+++ b/lib/sticky-renderer.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { render } from 'react-dom';
 import StickyNote from './components/sticky-note';
-import store from './store';
 
 render(<StickyNote />, document.querySelector('.sticky'));

--- a/lib/store.js
+++ b/lib/store.js
@@ -9,14 +9,6 @@ store.emit('change');
 
 let idCounter = localStorage.getItem("idCounter") || 0;
 
-let stickies = [];
-
-store.addSticky = (file) => {
-  stickies = stickies.concat(file);
-};
-
-store.currentSticky = () => stickies[stickies.length - 1];
-
 store.all = () => files.concat([]);
 
 store.add = ({fileName, content, active}) => {

--- a/lib/store.js
+++ b/lib/store.js
@@ -59,8 +59,9 @@ store.saveContent = (id, updatedContent) => {
     }
     return Object.assign({}, file);
   });
-  updateWindows(files);
-  // store.emit('change', files);
+  let currentWindow = remote.getCurrentWindow();
+  store.emit('change', files);
+  updateWindows(files, currentWindow);
 };
 
 store.saveActiveFile = () => {
@@ -120,9 +121,10 @@ ipcRenderer.on('file-opened', (event, file) => {
   store.add(file);
 });
 
-ipcRenderer.on('window-updated', (event, updatedFiles) => {
+ipcRenderer.on('window-updated', (event, updatedFiles, currentWindow) => {
   files = updatedFiles;
   store.emit('change', files);
+  currentWindow.focus();
 });
 
 

--- a/lib/store.js
+++ b/lib/store.js
@@ -1,5 +1,7 @@
 import EventEmitter from 'events';
 import { ipcRenderer } from 'electron';
+import { remote } from 'electron';
+const {updateWindows} = remote.require(`${__dirname}/main`);
 
 const store = new EventEmitter();
 
@@ -57,7 +59,8 @@ store.saveContent = (id, updatedContent) => {
     }
     return Object.assign({}, file);
   });
-  store.emit('change', files);
+  updateWindows(files);
+  // store.emit('change', files);
 };
 
 store.saveActiveFile = () => {
@@ -116,6 +119,12 @@ store.saveGist = (fileName, gistUrl) => {
 ipcRenderer.on('file-opened', (event, file) => {
   store.add(file);
 });
+
+ipcRenderer.on('window-updated', (event, updatedFiles) => {
+  files = updatedFiles;
+  store.emit('change', files);
+});
+
 
 ipcRenderer.on('file-saved', (event, fileName, id) => {
   store.updateFileName(fileName, id);

--- a/lib/store.js
+++ b/lib/store.js
@@ -60,7 +60,7 @@ store.saveContent = (id, updatedContent) => {
     return Object.assign({}, file);
   });
   let currentWindow = remote.getCurrentWindow();
-  // console.log(currentWindow)
+  store.emit("change", files);
   updateWindows(files, currentWindow);
 };
 

--- a/lib/store.js
+++ b/lib/store.js
@@ -60,7 +60,7 @@ store.saveContent = (id, updatedContent) => {
     return Object.assign({}, file);
   });
   let currentWindow = remote.getCurrentWindow();
-
+  // console.log(currentWindow)
   updateWindows(files, currentWindow);
 };
 

--- a/lib/store.js
+++ b/lib/store.js
@@ -72,7 +72,6 @@ store.saveActiveFile = () => {
 };
 
 store.newFile = () => {
-  store.saveActiveFile();
   store.deselect();
   let id = ++idCounter;
   localStorage.setItem("idCounter", idCounter);
@@ -80,7 +79,6 @@ store.newFile = () => {
   files.unshift(newNote);
   files = Object.assign([], files);
   store.emit('change', files);
-  return newNote;
 };
 
 store.addMarkdown = (id) => {

--- a/lib/store.js
+++ b/lib/store.js
@@ -60,7 +60,7 @@ store.saveContent = (id, updatedContent) => {
     return Object.assign({}, file);
   });
   let currentWindow = remote.getCurrentWindow();
-  store.emit('change', files);
+
   updateWindows(files, currentWindow);
 };
 
@@ -121,10 +121,11 @@ ipcRenderer.on('file-opened', (event, file) => {
   store.add(file);
 });
 
-ipcRenderer.on('window-updated', (event, updatedFiles, currentWindow) => {
-  files = updatedFiles;
-  store.emit('change', files);
-  currentWindow.focus();
+ipcRenderer.on('window-updated', (event, updatedFiles, currentWindow, windows) => {
+  // if (remote.getCurrentWindow() !== currentWindow) {
+    files = updatedFiles;
+    store.emit('change', files);
+  // }
 });
 
 

--- a/lib/style.css
+++ b/lib/style.css
@@ -124,6 +124,8 @@ button:hover {
 }
 
 .sticky-note {
+  padding-top: 40px;
+  padding-left: 10px;
   outline: none;
   width: 100%;
   height: 100vh;

--- a/lib/style.css
+++ b/lib/style.css
@@ -133,7 +133,10 @@ button:hover {
 }
 
 .sticky-note-body {
-  padding-top: 40px;
+  outline: none;
+  padding-top: 10px;
+  width: 100%;
+  height: 100vh;
   border: none;
   background-color: #F9F9B7;
 }

--- a/lib/style.css
+++ b/lib/style.css
@@ -124,11 +124,27 @@ button:hover {
 }
 
 .sticky-note {
-  padding-top: 40px;
   padding-left: 10px;
   outline: none;
   width: 100%;
   height: 100vh;
   border: none;
   background-color: #F9F9B7;
+}
+
+.sticky-note-body {
+  padding-top: 40px;
+  border: none;
+  background-color: #F9F9B7;
+}
+
+.toggle-on-top {
+  padding-top: 10px;
+  float: right;
+  background-color: #F4F44C;
+  border-radius: 10px;
+}
+
+.toggle-on-top:hover {
+  background-color: #B4B417;
 }

--- a/lib/update-content.js
+++ b/lib/update-content.js
@@ -1,3 +1,6 @@
 import store from './store';
 
-module.exports = (file, event) => store.saveContent(file.id, event.target.value);
+module.exports = (file, event) => {
+  console.log(event);
+  store.saveContent(file.id, event.target.value);
+};


### PR DESCRIPTION
Sticky correctly exports the current active note and is editable. It maintains it's state when main application window's active note is changed and additional stickies can be created from whichever note is active in the main window.

Changes to stickies or in the main active note window are not reflected in the other unless they are refreshed. When I add debuggers the change events are properly firing and updating the store but when the store emits a 'change' event, it only triggers the listener in the browser window that was actually changed. The issue appears to be in the listeners receiving change events that were triggered from a different browser window. Any ideas @stevekinney ?
