### PR TITLE
[WIP] Dynamic update sticky application

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -39,7 +39,6 @@ const newSticky = () => {
 const updateWindows = (files, currentWindow) => {
   let windowsSend = allWindows.map(function(activeWindow) {
     return () => activeWindow.window.webContents.send('window-updated', files);
-    // return activeWindow.call(this, 'window-updated', files);
   });
 
   async.parallel(windowsSend);

--- a/lib/update-content.js
+++ b/lib/update-content.js
@@ -1,6 +1,5 @@
 import store from './store';
 
 module.exports = (file, event) => {
-  console.log(event);
   store.saveContent(file.id, event.target.value);
 };


### PR DESCRIPTION
Moving comments from fix-sticky branch to this to clean up master. Summary of previous comments below. This branch is attempting to coordinate communication between sticky windows and main application windows to dynamically update notes in each.

Original comments:

Sticky correctly exports the current active note and is editable. It maintains it's state when main application window's active note is changed and additional stickies can be created from whichever note is active in the main window.

Changes to stickies or in the main active note window are not reflected in the other unless they are refreshed. When I add debuggers the change events are properly firing and updating the store but when the store emits a 'change' event, it only triggers the listener in the browser window that was actually changed. The issue appears to be in the listeners receiving change events that were triggered from a different browser window. Any ideas @ stevekinney ?

Corrected this issue by having the main process track all windows and update each with content edits. Not sure if this is the best way but it allows edits in stickies to immediately impact main window and vice versa.

There's now a weird bug where when you try to type in the sticky note that has content and you click towards the top, the first character will type where you placed your cursor but then it jumps to the end of the note when you continue typing. Appears to be a side effect of iterating through all windows to send change events to their respect references of the store, which then emits a change to the listening components.

requiring async library and asynchronously calling on all of the windows to send update message does not appear to fix issue. Maybe try using websockets to connect browser windows to store events.

Also tried passing a reference to the application so that the new sticky window could derive it's file/note based on the state of the application component and would auto-update when it was updated but it comes back as either an empty object or undefined, depending on if I pass it as a property of the stickyWindow or hold it with getters and setters as a property of store. There doesn't seem to be a way to tie components together when they are in different windows and the work around of having each window send it's own update messages works but has intermittent jumping cursor syndrome.

@ stevekinney The cursor seems to be moving when opening a sticky note and the user types too fast.

@ JoshCheek Have you ever seen this behavior with state change in javascript? At normal typing speeds, the state seems to update just fine. Wondering if too may keys restarts the entire event and just starts the cursor back at the bottom?

Notes:

Iterating through windows, it shifts focus to main process
Then it refocuses to the window (sticky note)
Seems to be a state/focus issue
Todo:

Figure out how to maintain focus while delegating state changes
Have main pull data? (for loops would be to intensive though)
@ robbielane This might be a React issue as well. Maybe you would find pleasure in solving this?

original PR https://github.com/danjwinter/note-taker/pull/11
